### PR TITLE
Added disabling of button after alert is sent

### DIFF
--- a/src/components/Alerts/Alerts.jsx
+++ b/src/components/Alerts/Alerts.jsx
@@ -67,7 +67,11 @@ class FAQ extends Component {
 	}
 
   buttonFormatter(cell, row) {
-     return (<Button bsStyle="primary" onClick={() => sendNotification(row)}>Send</Button>);
+    if(row.sentDate){
+      return (<Button bsStyle="danger" disabled onClick={() => sendNotification(row)}>Already Sent</Button>);
+    } else {
+      return (<Button bsStyle="primary" onClick={() => sendNotification(row)}>Send</Button>);
+    }
   }
 
   render() {

--- a/src/components/Alerts/Alerts_utils.js
+++ b/src/components/Alerts/Alerts_utils.js
@@ -59,6 +59,9 @@ export function sendNotification(alert) {
   }).then(response => {
   }).catch(function (error) {
     console.log(error);
-    alert('Failed to send notifications!');
+    alert('Failed to send notification!');
+    return;
   });
+  alert.sentDate = new Date();
+  handleAlertEdit(alert);
 }


### PR DESCRIPTION
Issue #: 156

User can only send alerts once, the button is disabled if the alert has been sent
Once the button is clicked, the alert is updated with the sent date